### PR TITLE
Bump bindgen to 0.69

### DIFF
--- a/mdbx-sys/Cargo.toml
+++ b/mdbx-sys/Cargo.toml
@@ -26,7 +26,7 @@ libc = "0.2"
 [build-dependencies]
 cmake = "0.1"
 cc = "1.0"
-bindgen = { version = "0.59", default-features = false, features = ["runtime"] }
+bindgen = { version = "0.69", default-features = false, features = ["runtime"] }
 
 [features]
 cmake-build = []

--- a/mdbx-sys/build.rs
+++ b/mdbx-sys/build.rs
@@ -1,4 +1,7 @@
-use bindgen::callbacks::{IntKind, ParseCallbacks};
+use bindgen::{
+    callbacks::{IntKind, ParseCallbacks},
+    Formatter,
+};
 use std::{env, path::PathBuf};
 
 #[derive(Debug)]
@@ -66,7 +69,7 @@ fn main() {
         .prepend_enum_name(false)
         .generate_comments(false)
         .disable_header_comment()
-        .rustfmt_bindings(true)
+        .formatter(Formatter::None)
         .generate()
         .expect("Unable to generate bindings");
 


### PR DESCRIPTION
This fixes a build issue that occurs with recent versions of `rustc`.

Before this patch:

```
error: failed to run custom build command for `mdbx-sys v0.11.6-4 (/Users/antoine/dev/libmdbx-rs/mdbx-sys)`

Caused by:
  process didn't exit successfully: `/Users/antoine/dev/libmdbx-rs/target/debug/build/mdbx-sys-697a80930844d123/build-script-build` (exit status: 101)
  --- stderr
  thread 'main' panicked at /Users/antoine/.cargo/registry/src/index.crates.io-6f17d22bba15001f/bindgen-0.59.2/src/ir/context.rs:878:9:
  "MDBX_version_info_struct_(unnamed_at_/Users/antoine/dev/libmdbx-rs/mdbx-sys/libmdbx/mdbx_h_611_3)" is not a valid Ident
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```